### PR TITLE
Update device class to SensorDeviceClass.MONETARY

### DIFF
--- a/custom_components/binance/binance_ticker_sensor.py
+++ b/custom_components/binance/binance_ticker_sensor.py
@@ -6,8 +6,9 @@ import decimal
 import requests
 from requests import RequestException
 from homeassistant.helpers.entity import Entity
+from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import (
-    STATE_UNKNOWN, DEVICE_CLASS_MONETARY
+    STATE_UNKNOWN
 )
 
 
@@ -17,7 +18,7 @@ logger = logging.getLogger(__name__)
 class BinanceTickerSensor(Entity):
 
     def __init__(self, symbol):
-        self._attr_device_class = DEVICE_CLASS_MONETARY
+        self._attr_device_class = SensorDeviceClass.MONETARY
         self._name = "Binance Ticker "+symbol.upper()
         self._symbol = symbol
         self._state = STATE_UNKNOWN


### PR DESCRIPTION
This change updates the deprecated DEVICE_CLASS_MONETARY to the new SensorDeviceClass.MONETARY as per the latest Home Assistant requirements. This update ensures compatibility with future versions of Home Assistant and avoids the use of deprecated constants, enhancing the overall code quality and maintainability of the home-assistant-binance integration.

"DEVICE_CLASS_MONETARY was used from binance, this is a deprecated constant which will be removed in HA Core 2025.1. Use SensorDeviceClass.MONETARY instead, please create a bug report at https://github.com/Kartax/home-assistant-binance/issues"