### PR TITLE
feat: add optional wallet balance sensors (v1.3.0b1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A Home Assistant Integration for the cryptocurrency trading platform [Binance](h
 Features:
  - [x] pull prices of a configurable list of currency pairs (e.g. BTCUSDT, XRPBTC...)
  - [x] additional attributes for each currency pair (priceChange, highPrice, lowPrice, volume, ...)
+ - [x] optionally pull wallet balances for configured assets (requires Binance API key & secret)
 
 ![screenshot_2](images/screenshot_2.png) ![screenshot_1](images/screenshot_1.png) 
 
@@ -21,8 +22,10 @@ or manually add this repository by using the "three-dots-menu" at the top right 
 
 
 ### Configuration
-Configure the sensor(s) in ``configuration.yaml``. 
-```
+Configure the sensor(s) in ``configuration.yaml``.
+
+#### Ticker only (no API key required)
+```yaml
 sensor:
   - platform: binance
     decimals: 8
@@ -30,5 +33,42 @@ sensor:
     symbols:
       - BTCUSDT
       - ETHUSDT
-      - ...
 ```
+
+#### Ticker + Wallet balances (API key required)
+
+To enable wallet balance sensors you need a Binance API key with **read permissions** (no trading permissions required).
+Create one at [Binance API Management](https://www.binance.com/en/my/settings/api-management).
+
+```yaml
+sensor:
+  - platform: binance
+    decimals: 8
+    update_interval: 60
+    symbols:
+      - BTCUSDT
+      - ETHUSDT
+    api_key: "YOUR_BINANCE_API_KEY"
+    api_secret: "YOUR_BINANCE_API_SECRET"
+    wallet_assets:
+      - BTC
+      - ETH
+      - USDT
+      - BNB
+```
+
+Each `wallet_assets` entry creates a dedicated sensor named `sensor.binance_wallet_<ASSET>` with the following attributes:
+
+| Attribute | Description |
+|-----------|-------------|
+| `free`    | Available (spendable) balance |
+| `locked`  | Balance currently locked in open orders |
+| `total`   | `free` + `locked` |
+
+The sensor **state** is the `free` balance. Unit of measurement is the asset symbol (e.g. `BTC`).
+
+> **Security note:** It is recommended to store your API credentials in `secrets.yaml` and reference them via `!secret`:
+> ```yaml
+> api_key: !secret binance_api_key
+> api_secret: !secret binance_api_secret
+> ```

--- a/custom_components/binance/binance_wallet_sensor.py
+++ b/custom_components/binance/binance_wallet_sensor.py
@@ -1,0 +1,114 @@
+"""Binance Wallet Sensor - fetches account balances using signed API requests"""
+
+import logging
+import asyncio
+import aiohttp
+import hashlib
+import hmac
+import time
+from datetime import datetime
+from homeassistant.helpers.entity import Entity
+from homeassistant.const import STATE_UNKNOWN
+
+logger = logging.getLogger(__name__)
+
+BINANCE_API_BASE = "https://api.binance.com"
+
+
+class BinanceWalletSensor(Entity):
+    """Sensor for a single Binance wallet asset balance."""
+
+    def __init__(self, asset, api_key, api_secret, decimals, update_interval):
+        self._asset = asset.upper()
+        self._api_key = api_key
+        self._api_secret = api_secret
+        self._decimals = decimals
+        self._update_interval = update_interval
+        self._name = f"Binance Wallet {self._asset}"
+        self._state = STATE_UNKNOWN
+        self._data = {}
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def state(self):
+        return self._state
+
+    @property
+    def unit_of_measurement(self):
+        return self._asset
+
+    @property
+    def icon(self):
+        return "mdi:wallet"
+
+    @property
+    def extra_state_attributes(self):
+        return self._data
+
+    def _sign_params(self, params: str) -> str:
+        """Create HMAC-SHA256 signature for Binance API."""
+        return hmac.new(
+            self._api_secret.encode("utf-8"),
+            params.encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+
+    async def async_added_to_hass(self):
+        logger.debug(
+            "Adding wallet sensor %s with update interval of %s seconds",
+            self._name,
+            self._update_interval,
+        )
+        await self.schedule_update()
+
+    async def schedule_update(self):
+        logger.debug("Updating wallet sensor %s at %s", self._name, datetime.now())
+
+        timestamp = int(time.time() * 1000)
+        query_string = f"timestamp={timestamp}"
+        signature = self._sign_params(query_string)
+        url = f"{BINANCE_API_BASE}/api/v3/account?{query_string}&signature={signature}"
+
+        headers = {"X-MBX-APIKEY": self._api_key}
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(url, headers=headers, timeout=10) as response:
+                    if response.status != 200:
+                        raise Exception(f"Error response ({response.status}): {await response.text()}")
+                    account_data = await response.json()
+                    balances = account_data.get("balances", [])
+
+                    # Find the balance for this asset
+                    asset_balance = next(
+                        (b for b in balances if b["asset"] == self._asset),
+                        None,
+                    )
+
+                    if asset_balance is None:
+                        logger.warning("Asset %s not found in Binance account", self._asset)
+                        self._state = 0.0
+                        self._data = {"free": 0.0, "locked": 0.0}
+                    else:
+                        free = round(float(asset_balance["free"]), self._decimals)
+                        locked = round(float(asset_balance["locked"]), self._decimals)
+                        self._state = free
+                        self._data = {
+                            "free": free,
+                            "locked": locked,
+                            "total": round(free + locked, self._decimals),
+                        }
+                        logger.debug(
+                            "Wallet %s: free=%s, locked=%s",
+                            self._asset,
+                            free,
+                            locked,
+                        )
+        except Exception as e:
+            logger.error("Error updating wallet sensor %s - %s", self._name, e)
+
+        await asyncio.sleep(self._update_interval)
+        asyncio.create_task(self.schedule_update())

--- a/custom_components/binance/const.py
+++ b/custom_components/binance/const.py
@@ -3,3 +3,5 @@
 CONF_SYMBOLS = "symbols"
 CONF_DECIMALS = "decimals"
 CONF_UPDATE_INVERVAL = "update_interval"
+CONF_API_KEY = "api_key"
+CONF_API_SECRET = "api_secret"

--- a/custom_components/binance/manifest.json
+++ b/custom_components/binance/manifest.json
@@ -8,5 +8,5 @@
     "integration_type": "hub",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/Kartax/home-assistant-binance/issues",
-    "version": "1.2.1"
+    "version": "1.3.0b1"
 }

--- a/custom_components/binance/sensor.py
+++ b/custom_components/binance/sensor.py
@@ -7,10 +7,13 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 from .const import (
     CONF_SYMBOLS,
     CONF_DECIMALS,
-    CONF_UPDATE_INVERVAL
+    CONF_UPDATE_INVERVAL,
+    CONF_API_KEY,
+    CONF_API_SECRET,
 )
 
 from .binance_ticker_sensor import BinanceTickerSensor
+from .binance_wallet_sensor import BinanceWalletSensor
 
 
 logger = logging.getLogger(__name__)
@@ -19,7 +22,10 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_SYMBOLS): vol.All(cv.ensure_list, [cv.string]),
         vol.Optional(CONF_DECIMALS, default=8): cv.positive_int,
-        vol.Optional(CONF_UPDATE_INVERVAL, default=60): cv.positive_int
+        vol.Optional(CONF_UPDATE_INVERVAL, default=60): cv.positive_int,
+        vol.Optional(CONF_API_KEY): cv.string,
+        vol.Optional(CONF_API_SECRET): cv.string,
+        vol.Optional("wallet_assets"): vol.All(cv.ensure_list, [cv.string]),
     }
 )
 
@@ -27,7 +33,27 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     symbols = config.get(CONF_SYMBOLS)
     decimals = config.get(CONF_DECIMALS)
     updateInterval = config.get(CONF_UPDATE_INVERVAL)
+    api_key = config.get(CONF_API_KEY)
+    api_secret = config.get(CONF_API_SECRET)
+    wallet_assets = config.get("wallet_assets", [])
 
+    # Ticker sensors (always created)
     for symbol in symbols:
         logger.debug("Setup BinanceTickerSensor %s %s %s", symbol, decimals, updateInterval)
         add_entities([BinanceTickerSensor(symbol, decimals, updateInterval)], True)
+
+    # Wallet sensors (only if api_key and api_secret are provided)
+    if api_key and api_secret:
+        if not wallet_assets:
+            logger.warning(
+                "Binance API key and secret provided, but no 'wallet_assets' configured. "
+                "Add a 'wallet_assets' list to track your balances."
+            )
+        for asset in wallet_assets:
+            logger.debug("Setup BinanceWalletSensor %s", asset)
+            add_entities([BinanceWalletSensor(asset, api_key, api_secret, decimals, updateInterval)], True)
+    elif wallet_assets:
+        logger.warning(
+            "Binance 'wallet_assets' configured but 'api_key' and/or 'api_secret' are missing. "
+            "Wallet sensors will not be created."
+        )


### PR DESCRIPTION
## Summary

Adds support for fetching Binance account wallet balances as Home Assistant sensors.

### Changes
- New `BinanceWalletSensor` using HMAC-SHA256 signed `/api/v3/account` endpoint
- Optional `api_key`, `api_secret`, and `wallet_assets` config keys in `configuration.yaml`
- One sensor per configured asset with `free`, `locked`, `total` attributes
- Sensor state = free balance, unit = asset symbol (e.g. BTC)
- Clear log warnings when credentials are partially missing
- Version bumped to `1.3.0b1`
- README updated with full configuration examples and `secrets.yaml` security hint

### Security
API key only needs **read** permissions. No trading permissions required.