### PR TITLE
fix: add exc_info to earn total error logging

### DIFF
--- a/custom_components/binance/binance_earn_total_sensor.py
+++ b/custom_components/binance/binance_earn_total_sensor.py
@@ -198,7 +198,7 @@ class BinanceEarnTotalSensor(Entity):
                     total_usd,
                 )
         except Exception as e:
-            logger.error("Error updating earn total sensor %s - %s", self._name, e)
+            logger.error("Error updating earn total sensor %s - %s", self._name, e, exc_info=True)
 
         await asyncio.sleep(self._update_interval)
         asyncio.create_task(self.schedule_update())


### PR DESCRIPTION
Adds `exc_info=True` to the earn total sensor error log so the full traceback appears in HA logs — makes it possible to diagnose why the sensor stays `unknown`.