### PR TITLE
fix: remove spaces from symbols JSON parameter for Binance price API

### DIFF
--- a/custom_components/binance/binance_earn_total_sensor.py
+++ b/custom_components/binance/binance_earn_total_sensor.py
@@ -149,7 +149,7 @@ class BinanceEarnTotalSensor(Entity):
                 non_stable = [a for a in all_assets if a not in USD_STABLE]
 
                 if non_stable:
-                    symbols_param = json.dumps([f"{a}USDT" for a in non_stable])
+                    symbols_param = json.dumps([f"{a}USDT" for a in non_stable], separators=(",", ":"))
                     async with session.get(
                         f"{BINANCE_API_BASE}/api/v3/ticker/price",
                         params={"symbols": symbols_param},


### PR DESCRIPTION
## Bug Fix

`json.dumps(["BTCUSDT", "ETHUSDT"])` produces `["BTCUSDT", "ETHUSDT"]` — the spaces after commas cause Binance to return HTTP 400:
> Illegal characters found in parameter 'symbols'

Fix: use `separators=(",", ":")` to produce `["BTCUSDT","ETHUSDT"]` without spaces.