### PR TITLE
feat: add GUI config flow, migrate from YAML platform config (v2.0.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,45 +21,41 @@ or manually add this repository by using the "three-dots-menu" at the top right 
 
 ### Configuration
 
-#### Without API key (ticker only)
+This integration is configured via the Home Assistant GUI — no YAML required.
 
-```yaml
-sensor:
-  - platform: binance
-    decimals: 8
-    update_interval: 60
-    symbols:
-      - BTCUSDT
-      - ETHUSDT
-```
+> **Migrating from YAML?** Existing `configuration.yaml` entries are automatically imported on first startup. You can then remove them from your YAML file.
 
-Creates one price sensor per symbol.
+#### Step 1 — Add the integration
 
-#### With API key (ticker + wallet + earn)
+Go to **Settings → Integrations → Add Integration** and search for **Binance**.
 
-```yaml
-sensor:
-  - platform: binance
-    symbols:
-      - BTCUSDT
-      - ETHUSDT
-    api_key: !secret binance_api_key
-    api_secret: !secret binance_api_secret
-    wallet_assets:            # optional: per-asset Spot sensors
-      - BTC
-      - ETH
-      - USDT
-    wallet_earn_assets:       # optional: per-asset Earn sensors
-      - USDT
-      - BTC
-```
+Enter your credentials and preferences:
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| API Key | No | _(empty)_ | Binance API key — needed for wallet and earn sensors |
+| API Secret | No | _(empty)_ | Binance API secret |
+| Decimal places | No | 8 | Number of decimal places for sensor values |
+| Update interval (seconds) | No | 60 | How often sensors refresh |
+
+#### Step 2 — Configure symbols and assets
+
+After the integration is added, click the **gear icon** (Configure) to set up your ticker symbols and wallet assets:
+
+| Field | Description | Example |
+|-------|-------------|---------|
+| Ticker symbols | Comma-separated trading pairs (required) | `BTCUSDT,ETHUSDT` |
+| Spot wallet assets | Comma-separated assets for per-asset Spot sensors (optional) | `BTC,ETH,USDT` |
+| Earn wallet assets | Comma-separated assets for per-asset Earn sensors (optional) | `USDT,BTC` |
+
+#### Sensors created
 
 | Sensor | Created when | Description |
 |--------|--------------|-------------|
 | Binance Ticker {SYMBOL} | always | Current price of the trading pair |
-| Binance Wallet Total (USD) | api_key set | Estimated Spot wallet value in USD |
-| Binance Wallet {ASSET} | wallet_assets configured | Spot balance per asset |
-| Binance Earn Total (USD) | api_key set | Estimated Earn portfolio value in USD (flexible + locked) |
-| Binance Earn {ASSET} | wallet_earn_assets configured | Earn balance per asset (flexible + locked combined) |
+| Binance Wallet Total (USD) | API key set | Estimated Spot wallet value in USD |
+| Binance Wallet {ASSET} | Spot wallet assets configured | Spot balance per asset |
+| Binance Earn Total (USD) | API key set | Estimated Earn portfolio value in USD (flexible + locked) |
+| Binance Earn {ASSET} | Earn wallet assets configured | Earn balance per asset (flexible + locked combined) |
 
-Store your API credentials in `secrets.yaml` and reference them with `!secret`. The API key only needs read permissions — no trading permissions required.
+The API key only needs read permissions — no trading permissions required.

--- a/custom_components/binance/__init__.py
+++ b/custom_components/binance/__init__.py
@@ -1,1 +1,71 @@
 """Binance Integration for Home Assistant"""
+
+import homeassistant.helpers.config_validation as cv
+import voluptuous as vol
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+from .const import (
+    CONF_API_KEY,
+    CONF_API_SECRET,
+    CONF_DECIMALS,
+    CONF_SYMBOLS,
+    CONF_UPDATE_INVERVAL,
+    CONF_WALLET_ASSETS,
+    CONF_WALLET_EARN_ASSETS,
+    DOMAIN,
+)
+
+PLATFORMS = [Platform.SENSOR]
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN: vol.All(
+            cv.ensure_list,
+            [
+                vol.Schema(
+                    {
+                        vol.Required(CONF_SYMBOLS): vol.All(cv.ensure_list, [cv.string]),
+                        vol.Optional(CONF_DECIMALS, default=8): cv.positive_int,
+                        vol.Optional(CONF_UPDATE_INVERVAL, default=60): cv.positive_int,
+                        vol.Optional(CONF_API_KEY): cv.string,
+                        vol.Optional(CONF_API_SECRET): cv.string,
+                        vol.Optional(CONF_WALLET_ASSETS): vol.All(cv.ensure_list, [cv.string]),
+                        vol.Optional(CONF_WALLET_EARN_ASSETS): vol.All(cv.ensure_list, [cv.string]),
+                    }
+                )
+            ],
+        )
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
+
+async def async_setup(hass: HomeAssistant, config: dict) -> bool:
+    """Trigger import flow for existing YAML configs."""
+    if DOMAIN not in config:
+        return True
+    for entry_config in config[DOMAIN]:
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": "import"},
+                data=entry_config,
+            )
+        )
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    entry.async_on_unload(entry.add_update_listener(async_update_listener))
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+
+async def async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/binance/config_flow.py
+++ b/custom_components/binance/config_flow.py
@@ -1,0 +1,131 @@
+"""Config flow for Binance integration."""
+
+import voluptuous as vol
+from homeassistant import config_entries
+from homeassistant.core import callback
+
+from .const import (
+    CONF_API_KEY,
+    CONF_API_SECRET,
+    CONF_DECIMALS,
+    CONF_SYMBOLS,
+    CONF_UPDATE_INVERVAL,
+    CONF_WALLET_ASSETS,
+    CONF_WALLET_EARN_ASSETS,
+    DOMAIN,
+)
+
+
+class BinanceConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Binance."""
+
+    VERSION = 1
+
+    async def async_step_user(self, user_input=None):
+        """Step 1: credentials and basic setup."""
+        if self._async_current_entries():
+            return self.async_abort(reason="already_configured")
+
+        errors = {}
+
+        if user_input is not None:
+            await self.async_set_unique_id(DOMAIN)
+            self._abort_if_unique_id_configured()
+            return self.async_create_entry(title="Binance", data=user_input)
+
+        schema = vol.Schema(
+            {
+                vol.Optional(CONF_API_KEY, default=""): str,
+                vol.Optional(CONF_API_SECRET, default=""): str,
+                vol.Optional(CONF_DECIMALS, default=8): int,
+                vol.Optional(CONF_UPDATE_INVERVAL, default=60): int,
+            }
+        )
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=schema,
+            errors=errors,
+        )
+
+    async def async_step_import(self, import_data):
+        """Handle import from YAML configuration."""
+        if self._async_current_entries():
+            return self.async_abort(reason="already_configured")
+
+        await self.async_set_unique_id(DOMAIN)
+        self._abort_if_unique_id_configured()
+
+        symbols = import_data.get(CONF_SYMBOLS, [])
+        symbols_str = ",".join(symbols) if isinstance(symbols, list) else symbols
+
+        wallet_assets = import_data.get(CONF_WALLET_ASSETS, [])
+        wallet_assets_str = ",".join(wallet_assets) if isinstance(wallet_assets, list) else (wallet_assets or "")
+
+        wallet_earn_assets = import_data.get(CONF_WALLET_EARN_ASSETS, [])
+        wallet_earn_assets_str = (
+            ",".join(wallet_earn_assets) if isinstance(wallet_earn_assets, list) else (wallet_earn_assets or "")
+        )
+
+        entry_data = {
+            CONF_API_KEY: import_data.get(CONF_API_KEY, ""),
+            CONF_API_SECRET: import_data.get(CONF_API_SECRET, ""),
+            CONF_DECIMALS: import_data.get(CONF_DECIMALS, 8),
+            CONF_UPDATE_INVERVAL: import_data.get(CONF_UPDATE_INVERVAL, 60),
+        }
+
+        entry_options = {
+            CONF_SYMBOLS: symbols_str,
+            CONF_WALLET_ASSETS: wallet_assets_str,
+            CONF_WALLET_EARN_ASSETS: wallet_earn_assets_str,
+        }
+
+        return self.async_create_entry(title="Binance", data=entry_data, options=entry_options)
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        return OptionsFlowHandler(config_entry)
+
+
+class OptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle options for Binance."""
+
+    def __init__(self, config_entry):
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input=None):
+        """Manage symbols and asset lists."""
+        errors = {}
+
+        if user_input is not None:
+            symbols_str = user_input.get(CONF_SYMBOLS, "").strip()
+            if not symbols_str:
+                errors[CONF_SYMBOLS] = "symbols_required"
+            else:
+                return self.async_create_entry(title="", data=user_input)
+
+        current_options = self.config_entry.options
+
+        schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_SYMBOLS,
+                    default=current_options.get(CONF_SYMBOLS, ""),
+                ): str,
+                vol.Optional(
+                    CONF_WALLET_ASSETS,
+                    default=current_options.get(CONF_WALLET_ASSETS, ""),
+                ): str,
+                vol.Optional(
+                    CONF_WALLET_EARN_ASSETS,
+                    default=current_options.get(CONF_WALLET_EARN_ASSETS, ""),
+                ): str,
+            }
+        )
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=schema,
+            errors=errors,
+        )

--- a/custom_components/binance/const.py
+++ b/custom_components/binance/const.py
@@ -1,5 +1,7 @@
 """constants"""
 
+DOMAIN = "binance"
+
 CONF_SYMBOLS = "symbols"
 CONF_DECIMALS = "decimals"
 CONF_UPDATE_INVERVAL = "update_interval"

--- a/custom_components/binance/manifest.json
+++ b/custom_components/binance/manifest.json
@@ -5,8 +5,9 @@
       "@Kartax"
     ],
     "documentation": "https://github.com/Kartax/home-assistant-binance",
+    "config_flow": true,
     "integration_type": "hub",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/Kartax/home-assistant-binance/issues",
-    "version": "1.3.0b5"
+    "version": "2.0.0"
 }

--- a/custom_components/binance/sensor.py
+++ b/custom_components/binance/sensor.py
@@ -36,6 +36,39 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 
+async def async_setup_entry(hass, entry, async_add_entities):
+    data = entry.data
+    options = entry.options
+
+    api_key = data.get(CONF_API_KEY, "")
+    api_secret = data.get(CONF_API_SECRET, "")
+    decimals = data.get(CONF_DECIMALS, 8)
+    update_interval = data.get(CONF_UPDATE_INVERVAL, 60)
+
+    symbols_str = options.get(CONF_SYMBOLS, data.get(CONF_SYMBOLS, ""))
+    symbols = [s.strip() for s in symbols_str.split(",") if s.strip()]
+
+    wallet_assets_str = options.get(CONF_WALLET_ASSETS, data.get(CONF_WALLET_ASSETS, ""))
+    wallet_assets = [s.strip() for s in wallet_assets_str.split(",") if s.strip()] if wallet_assets_str else []
+
+    wallet_earn_assets_str = options.get(CONF_WALLET_EARN_ASSETS, data.get(CONF_WALLET_EARN_ASSETS, ""))
+    wallet_earn_assets = [s.strip() for s in wallet_earn_assets_str.split(",") if s.strip()] if wallet_earn_assets_str else []
+
+    entities = []
+    for symbol in symbols:
+        entities.append(BinanceTickerSensor(symbol, decimals, update_interval))
+
+    if api_key and api_secret:
+        entities.append(BinanceWalletTotalSensor(api_key, api_secret, decimals, update_interval))
+        entities.append(BinanceEarnTotalSensor(api_key, api_secret, decimals, update_interval))
+        for asset in wallet_assets:
+            entities.append(BinanceWalletSensor(asset, api_key, api_secret, decimals, update_interval))
+        for asset in wallet_earn_assets:
+            entities.append(BinanceEarnAssetSensor(asset, api_key, api_secret, decimals, update_interval))
+
+    async_add_entities(entities, True)
+
+
 def setup_platform(hass, config, add_entities, discovery_info=None):
     symbols = config.get(CONF_SYMBOLS)
     decimals = config.get(CONF_DECIMALS)

--- a/custom_components/binance/strings.json
+++ b/custom_components/binance/strings.json
@@ -1,0 +1,35 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Binance",
+        "description": "Configure your Binance integration. API key and secret are optional — only needed for wallet and earn sensors.",
+        "data": {
+          "api_key": "API Key (optional)",
+          "api_secret": "API Secret (optional)",
+          "decimals": "Decimal places",
+          "update_interval": "Update interval (seconds)"
+        }
+      }
+    },
+    "error": {
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "Binance is already configured."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Binance Options",
+        "description": "Configure symbols and wallet assets. Use comma-separated values, e.g. BTCUSDT,ETHUSDT",
+        "data": {
+          "symbols": "Ticker symbols (e.g. BTCUSDT,ETHUSDT)",
+          "wallet_assets": "Spot wallet assets (e.g. BTC,ETH,USDT)",
+          "wallet_earn_assets": "Earn wallet assets (e.g. USDT,BTC)"
+        }
+      }
+    }
+  }
+}

--- a/custom_components/binance/translations/en.json
+++ b/custom_components/binance/translations/en.json
@@ -1,0 +1,35 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Binance",
+        "description": "Configure your Binance integration. API key and secret are optional — only needed for wallet and earn sensors.",
+        "data": {
+          "api_key": "API Key (optional)",
+          "api_secret": "API Secret (optional)",
+          "decimals": "Decimal places",
+          "update_interval": "Update interval (seconds)"
+        }
+      }
+    },
+    "error": {
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "Binance is already configured."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Binance Options",
+        "description": "Configure symbols and wallet assets. Use comma-separated values, e.g. BTCUSDT,ETHUSDT",
+        "data": {
+          "symbols": "Ticker symbols (e.g. BTCUSDT,ETHUSDT)",
+          "wallet_assets": "Spot wallet assets (e.g. BTC,ETH,USDT)",
+          "wallet_earn_assets": "Earn wallet assets (e.g. USDT,BTC)"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## v2.0.0 — GUI Configuration

The integration can now be configured entirely through the Home Assistant UI.

### What changed
- **config_flow.py**: new GUI setup flow (API key + settings) and options flow (symbols + assets)
- **__init__.py**: rewritten to use config entries (`async_setup_entry`, `async_unload_entry`)
- **sensor.py**: added `async_setup_entry`; old `setup_platform` kept for compatibility
- **manifest.json**: added `config_flow: true`, version `2.0.0`
- **strings.json** + **translations/en.json**: UI labels
- **README.md**: updated to describe GUI setup

### YAML migration
Existing `configuration.yaml` entries are **automatically imported** on first HA start after the update. No manual action needed — HA will show a notification to confirm the import.

### Setup (new installations)
Settings → Integrations → Add Integration → search **Binance**

### No breaking changes to sensors
All existing sensors (ticker, wallet, earn) work exactly as before.