### PR TITLE
fix: make sensor setup non-blocking to prevent HA startup timeouts

### DIFF
--- a/custom_components/binance/binance_earn_asset_sensor.py
+++ b/custom_components/binance/binance_earn_asset_sensor.py
@@ -101,7 +101,7 @@ class BinanceEarnAssetSensor(Entity):
             self._name,
             self._update_interval,
         )
-        await self.schedule_update()
+        asyncio.create_task(self.schedule_update())
 
     async def schedule_update(self):
         logger.debug("Updating earn asset sensor %s at %s", self._name, datetime.now())

--- a/custom_components/binance/binance_earn_total_sensor.py
+++ b/custom_components/binance/binance_earn_total_sensor.py
@@ -106,7 +106,7 @@ class BinanceEarnTotalSensor(Entity):
             self._name,
             self._update_interval,
         )
-        await self.schedule_update()
+        asyncio.create_task(self.schedule_update())
 
     async def schedule_update(self):
         logger.debug("Updating earn total sensor %s at %s", self._name, datetime.now())

--- a/custom_components/binance/binance_ticker_sensor.py
+++ b/custom_components/binance/binance_ticker_sensor.py
@@ -49,7 +49,7 @@ class BinanceTickerSensor(Entity):
             self._name,
             self._updateInterval,
         )
-        await self.schedule_update()
+        asyncio.create_task(self.schedule_update())
 
     async def schedule_update(self):
         logger.debug("Updating %s at %s", self._name, datetime.now())

--- a/custom_components/binance/binance_wallet_sensor.py
+++ b/custom_components/binance/binance_wallet_sensor.py
@@ -62,7 +62,7 @@ class BinanceWalletSensor(Entity):
             self._name,
             self._update_interval,
         )
-        await self.schedule_update()
+        asyncio.create_task(self.schedule_update())
 
     async def schedule_update(self):
         logger.debug("Updating wallet sensor %s at %s", self._name, datetime.now())

--- a/custom_components/binance/binance_wallet_total_sensor.py
+++ b/custom_components/binance/binance_wallet_total_sensor.py
@@ -65,7 +65,7 @@ class BinanceWalletTotalSensor(Entity):
             self._name,
             self._update_interval,
         )
-        await self.schedule_update()
+        asyncio.create_task(self.schedule_update())
 
     async def schedule_update(self):
         logger.debug("Updating wallet total sensor %s at %s", self._name, datetime.now())


### PR DESCRIPTION
## Bug Fix

**Problem:** HA showed 500 error when trying to configure the integration. Logs showed: `Setup of sensor platform binance is taking over 10 seconds.` and the config flow could not load.

**Root cause:** All 5 sensor classes had `await self.schedule_update()` in `async_added_to_hass`. Since `schedule_update` does a full API call + `await asyncio.sleep(update_interval)` before starting the next cycle, each sensor blocked HA entity setup for 60 seconds. With 5+ sensors, this timed out the entire platform setup.

**Fix:** Changed to `asyncio.create_task(self.schedule_update())` so the first API call runs in the background and HA setup completes immediately.

**Affected files:**
- binance_ticker_sensor.py
- binance_wallet_sensor.py
- binance_wallet_total_sensor.py
- binance_earn_total_sensor.py
- binance_earn_asset_sensor.py